### PR TITLE
Implement ability to "move" ship within build canvas

### DIFF
--- a/src/components/NavLink.js
+++ b/src/components/NavLink.js
@@ -16,7 +16,7 @@ const NavLink = ({ children, to, onClick, icon }) => {
 
   return (
     <li className={styles.box}>
-      <Link to={to} activeClassName={styles.active}>
+      <Link to={to} activeclassname={styles.active}>
         <div className={styles.inner}>
           {icon}
           <span>{children}</span>

--- a/src/components/Ship.js
+++ b/src/components/Ship.js
@@ -92,6 +92,45 @@ const Ship = ({ name, shipId, crew, tiles, dimensions }) => {
             ))}
           </div>
           <ShipImage tiles={tiles} dimensions={dimensions} />
+          <div style={{ textAlign: "center" }}>
+          Nudge<br />
+          <button onClick={(e) => {
+            e.preventDefault();
+            editGameData({
+              type: "nudge",
+              value: 'left',
+              ship: name
+            })
+          }
+          }>⬅️</button>
+          <button onClick={(e) => {
+            e.preventDefault();
+            editGameData({
+              type: "nudge",
+              value: 'up',
+              ship: name
+            })
+          }
+          }>⬆️</button>
+          <button onClick={(e) => {
+            e.preventDefault();
+            editGameData({
+              type: "nudge",
+              value: 'down',
+              ship: name
+            })
+          }
+          }>⬇️</button>
+          <button onClick={(e) => {
+            e.preventDefault();
+            editGameData({
+              type: "nudge",
+              value: 'right',
+              ship: name
+            })
+          }
+          }>➡️</button>
+        </div>
         </div>
         <div></div>
         <div>

--- a/src/components/Storage.js
+++ b/src/components/Storage.js
@@ -17,6 +17,7 @@ const Storage = ({ shipId, tileDetails, inventory, rules, eatAllowed }) => {
         <span>Direct eat allowed</span>
       </label>
       <table className={styles.table}>
+        <tbody>
         {(!inventory || inventory.length === 0) && (
           <tr>
             <td>Emtpy</td>
@@ -31,6 +32,7 @@ const Storage = ({ shipId, tileDetails, inventory, rules, eatAllowed }) => {
               item={item}
             />
           ))}
+        </tbody>
       </table>
     </Card>
   );

--- a/src/components/shipimage.module.css
+++ b/src/components/shipimage.module.css
@@ -1,5 +1,5 @@
 .image {
   -ms-interpolation-mode: nearest-neighbor;
   image-rendering: pixelated;
-  transform: rotate(90deg);
+  transform: rotate(180deg) scaleX(-1);
 }

--- a/src/context/SaveContext.js
+++ b/src/context/SaveContext.js
@@ -146,6 +146,8 @@ const gameReducer = (state, action) => {
 
         let newTiles = [... thisShip.tiles],
           newRoof = [... thisShip.roof],
+          newChars = [... thisShip.characters],
+          newRobots = thisShip.robots ? [... thisShip.robots] : [],
           newItems = thisShip.items ? [... thisShip.items] : [];
 
         // base (hull, buildings)
@@ -170,6 +172,20 @@ const gameReducer = (state, action) => {
           });
           newState.ships[shipIndex].items = newItems;
         }
+
+        // characters
+        newChars = newChars.map(char => {
+          let newChar = parse(char, action.value);
+          return newChar;
+        });
+        newState.ships[shipIndex].characters = newChars;
+
+        // robots
+        newRobots = newRobots.map(bot => {
+          let newBot = parse(bot, action.value);
+          return newBot;
+        });
+        newState.ships[shipIndex].robots = newRobots;
       }
       return newState;
     },
@@ -235,7 +251,7 @@ const SaveProvider = ({ children }) => {
 };
 
 const parse = (obj, dir, skip = false) => {
-  let skipList = ['bo']; // array of elements to skip
+  let skipList = []; // array of elements to skip
   let children = Object.keys(obj);
 
   children.forEach(child => {

--- a/src/context/SaveContext.js
+++ b/src/context/SaveContext.js
@@ -137,6 +137,20 @@ const gameReducer = (state, action) => {
       }
       return newState;
     },
+    nudge: () => {
+      const shipIndex = newState.ships.findIndex(
+        (ship) => ship.name === action.ship,
+      );
+      if (shipIndex >= 0) {
+        let newTiles = [... newState.ships[shipIndex].tiles];
+        newTiles = newTiles.map(tile => {
+          let newTile = parse(tile, action.value);
+          return newTile;
+        });
+        newState.ships[shipIndex].tiles = newTiles;
+      }
+      return newState;
+    },
   };
 
   if (!actions[action.type]) {
@@ -197,5 +211,28 @@ const SaveProvider = ({ children }) => {
     </SaveContext.Provider>
   );
 };
+
+const parse = (obj, dir) => {
+  let children = Object.keys(obj);
+  // let ret = {...obj};
+
+  children.forEach(child => {
+    if (child == '_attributes') {
+      if (obj._attributes?.sh != "61504" && // not border
+      Object.prototype.hasOwnProperty.call(obj._attributes, 'x')) { // has position
+        switch (dir) {
+          case 'left':  obj._attributes.x = '' + (parseInt(obj._attributes.x) - 1); break;
+          case 'right': obj._attributes.x = '' + (parseInt(obj._attributes.x) + 1); break;
+          case 'up':    obj._attributes.y = '' + (parseInt(obj._attributes.y) + 1); break;
+          case 'down':  obj._attributes.y = '' + (parseInt(obj._attributes.y) - 1); break;
+        }
+      }
+    } else {
+      obj[child] = parse(obj[child], dir);
+    }
+  });
+
+  return obj;
+}
 
 export default SaveProvider;

--- a/src/lib/createShipImage.js
+++ b/src/lib/createShipImage.js
@@ -112,7 +112,7 @@ const createShipImage = (tiles, dimensions) => {
         imgBuffer[pos] = 20;
         imgBuffer[pos + 1] = 20;
         imgBuffer[pos + 2] = 0;
-        imgBuffer[pos + 3] = 0;
+        imgBuffer[pos + 3] = 128;
         continue;
       }
       // Hull blocks

--- a/src/lib/parseGameData.js
+++ b/src/lib/parseGameData.js
@@ -21,7 +21,7 @@ const parseGameData = (data) => {
       };
       shipObject.characters = ship.characters?.c || [];
       shipObject.monsters = ship.characters?.m || [];
-      shipObject.robots = ship.characters?.r || [];
+      shipObject.robots = ship.robots?.m || [];
       shipObject.items = ship.items?.i || [];
       
       return shipObject;
@@ -35,7 +35,7 @@ const parseGameData = (data) => {
       craftObject.id = craft._attributes.id;
       craftObject.name = craft._attributes.cname || null;
       craftObject.characters = craft.characters?.c || [];
-      craftObject.robots = craft.characters?.r || [];
+      craftObject.robots = craft.robots?.m || [];
 
       return craftObject;
     });

--- a/src/lib/parseGameData.js
+++ b/src/lib/parseGameData.js
@@ -14,6 +14,7 @@ const parseGameData = (data) => {
       shipObject.name = ship._attributes.sname;
       shipObject.id = ship._attributes.sid;
       shipObject.tiles = ship.e;
+      shipObject.roof = ship.roof.e;
       shipObject.dimensions = {
         x: parseInt(ship._attributes.sx, 10),
         y: parseInt(ship._attributes.sy, 10),
@@ -21,7 +22,8 @@ const parseGameData = (data) => {
       shipObject.characters = ship.characters?.c || [];
       shipObject.monsters = ship.characters?.m || [];
       shipObject.robots = ship.characters?.r || [];
-
+      shipObject.items = ship.items?.i || [];
+      
       return shipObject;
     });
   }

--- a/src/lib/rewriteGameData.js
+++ b/src/lib/rewriteGameData.js
@@ -19,8 +19,9 @@ const rewriteGameData = (file, data) => {
     ship._attributes.sname = edited.name;
 
     ship.characters.c = edited.characters;
+    
+    ship.robots.m = edited.robots;
     // ship.monsters.c = edited.monsters;
-    // ship.robots.c = edited.robots;
   });
 
   output.game.crafts.c.forEach((craft) => {

--- a/src/lib/rewriteGameData.js
+++ b/src/lib/rewriteGameData.js
@@ -12,6 +12,10 @@ const rewriteGameData = (file, data) => {
 
     ship.e = edited.tiles;
 
+    ship.roof.e = edited.roof;
+    
+    ship.items.i = edited.items;
+
     ship._attributes.sname = edited.name;
 
     ship.characters.c = edited.characters;

--- a/src/lib/rewriteGameData.js
+++ b/src/lib/rewriteGameData.js
@@ -10,6 +10,8 @@ const rewriteGameData = (file, data) => {
       return item.id === ship._attributes.sid;
     });
 
+    ship.e = edited.tiles;
+
     ship._attributes.sname = edited.name;
 
     ship.characters.c = edited.characters;


### PR DESCRIPTION
Started playing SH recently and made a mistake of building my ship off-center.
After some searching I found this editor and added said function!

Essentially it modifies all the x,y values in ship.tiles (if it has x,y and is not the border)

Known issues:
- unbuilt blueprints doesn't move, but doesn't seem to break anything. just manually move the blueprint in game afterwards
- game will crash if any x, y values are negative


To do:
- discard forbidden blocks (drive plume, airlock docking space) if they move outside of the border
- prevent nudging of ship outside the border